### PR TITLE
PHP 8.0 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: required
 
 language: php
 php:
-  - '7.4'
+  - '8.0'
+  - nightly
 
 services:
   - docker

--- a/ds/ds.php
+++ b/ds/ds.php
@@ -436,12 +436,24 @@ namespace Ds {
      * <h3>Weaknesses
      * <li>shift(), unshift(), insert() and remove() are all O(n).
      *
+     * @link https://www.php.net/manual/en/class.ds-vector.php
+     *
      * @package Ds
      */
     class Vector implements Sequence
     {
 
         const MIN_CAPACITY = 10;
+
+        /**
+         * Creates a new instance, using either a traversable object or an array for the initial values.
+         *
+         * @param array|Traversable $values
+         */
+        public function __construct($values = null)
+        {
+        }
+
 
         /**
          * Ensures that enough memory is allocated for a required capacity.
@@ -1864,6 +1876,16 @@ namespace Ds {
     class Pair implements JsonSerializable
     {
         /**
+         * @var mixed
+         */
+        public $key;
+
+        /**
+         * @var mixed
+         */
+        public $value;
+
+        /**
          * Creates a new instance using a given key and value.
          *
          * @param mixed $key
@@ -2001,7 +2023,7 @@ namespace Ds {
          *
          * <p><b>Caution:</b> All comparisons are strict (type and value).
          *
-         * @param mixed ...$values  Values to check.
+         * @param mixed ...$values Values to check.
          *
          * @return bool
          *
@@ -2326,7 +2348,7 @@ namespace Ds {
          *
          * @link https://www.php.net/manual/en/ds-set.union.php
          *
-         * @param Set $set  The other set, to combine with the current instance.
+         * @param Set $set The other set, to combine with the current instance.
          *
          * @return Set A new set containing all the values of the current
          * instance as well as another set.
@@ -2728,6 +2750,16 @@ namespace Ds {
          * @return bool
          */
         public function isEmpty(): bool
+        {
+        }
+
+        /**
+         * Pushes a value with a given priority into the queue.
+         *
+         * @param mixed $value
+         * @param int   $priority
+         */
+        public function push($value, int $priority)
         {
         }
 


### PR DESCRIPTION
The Travis CI build and checks have failed on your PR - that's no wonder, since the build chain still uses 7.4. Let's see if and when Travis supports 8.0 and according nightlies.

I would expect the merge to fail, as Travis CI does not provide 8.0 yet - or at least does not document it. But the build chain should be changed to the new version accordingly.